### PR TITLE
upgraded from t2 to t3, and mysql from v8.0.33 to v8.0.35

### DIFF
--- a/react/scripts/terraform/ec2_database/main.tf
+++ b/react/scripts/terraform/ec2_database/main.tf
@@ -44,8 +44,8 @@ resource "aws_db_instance" "default" {
   allocated_storage      = 20    #  GBytes, minimum is 20 GB
   storage_type           = "gp2" #  "gp2" (general purpose SSD)
   engine                 = "mysql"
-  engine_version         = "8.0.33"
-  instance_class         = "db.t2.micro"
+  engine_version         = "8.0.35"
+  instance_class         = "db.t3.micro"
   name                   = var.mysql_db_name
   username               = var.mysql_user_name
   password               = var.mysql_password


### PR DESCRIPTION
Following an email from AWS, T2 is no longer available.   This PR upgrades from t2 to t3.  The updated from v8.0.33 to v8.0.35 was required.